### PR TITLE
Added matplotlib dependancy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setuptools.setup(author="John Coxon and Steve Milan",
                              "presented by Milan (2013) and Coxon et al. (2016).",
                  install_requires=[
                      "numpy",
-                     "pandas"
+                     "pandas",
+                     "matplotlib",
                  ],
                  long_description=long_description,
                  long_description_content_type="text/markdown",


### PR DESCRIPTION
I'm helping...

Installing using the `setup.py` doesn't work because its missing matplotlib from the dependancies.